### PR TITLE
Remove the date format of created_at column

### DIFF
--- a/models/message/columns.yaml
+++ b/models/message/columns.yaml
@@ -15,7 +15,6 @@ columns:
     created_at:
         label: janvince.smallcontactform::lang.models.message.columns.datetime
         type: datetime
-        format: j.n.Y H:i
         searchable: true
 
     name:


### PR DESCRIPTION
The default format type is support the multilingual display.