### PR TITLE
Add Spanish translations for messages

### DIFF
--- a/models/Settings.php
+++ b/models/Settings.php
@@ -336,6 +336,18 @@ class Settings extends Model
 
             ],
 
+            'es' => [
+
+                'autoreply' => [
+                    'janvince.smallcontactform::mail.autoreply_es' => 'janvince.smallcontactform::lang.mail.templates.autoreply_es',
+                ],
+
+                'notification' => [
+                    'janvince.smallcontactform::mail.notification_es' => 'janvince.smallcontactform::lang.mail.templates.notification_es',
+                ],
+
+            ],
+
         ];
 
         if( $locale and $templateType ) {

--- a/views/mail/autoreply_es.htm
+++ b/views/mail/autoreply_es.htm
@@ -1,0 +1,77 @@
+subject = "Confirmación del formulario de contacto"
+==
+
+Hola,
+
+esto es una confirmación del formulario de contacto.
+
+{% if fieldsDetails|length %}
+Ha enviado lo siguiente:
+
+<table border="0">
+
+    <tbody>
+
+        {% for field in fieldsDetails %}
+
+            {% if field.label == 'form_description' or field.label == 'form_alias' %}
+            {% else %}
+
+                <tr>
+                    <th style="vertical-align: top; text-align: left; padding-right: 10px;">{{ field.label }}</th>
+                    <td style="text-align: left;">{{ field.value|raw|nl2br }}</td>
+                    <th>{{field.label}}</th>
+                </tr>
+
+            {% endif %}
+
+        {% endfor %}
+
+    </tbody>
+
+</table>
+
+{% endif %}
+
+
+Le saluda atentamente,
+
+El formulario de contacto
+
+
+==
+
+<p>Hola,</p>
+
+<p>esto es una confirmación del formulario de contacto.</p>
+
+{% if fieldsDetails|length %}
+
+<br>
+
+<p>Ha enviado lo siguiente:</p>
+
+<table border="0">
+
+    <tbody>
+
+		{% for field in fieldsDetails %}
+
+			<tr>
+				<th style="vertical-align: top; text-align: left; padding-right: 10px;">{{ field.label }}</th>
+				<td style="text-align: left;">{{ field.value|raw|nl2br }}</td>
+			</tr>
+
+		{% endfor %}
+
+    </tbody>
+
+</table>
+
+{% endif %}
+
+<br>
+
+<p>Le saluda atentamente,<br>
+
+El formulario de contacto</p>

--- a/views/mail/notification_es.htm
+++ b/views/mail/notification_es.htm
@@ -1,0 +1,70 @@
+subject = "Notificación del formulario de contacto"
+==
+
+Hola,
+esto es una notificación de un formulario de contacto.
+
+{% if fields|length %}
+Contenido del formulario enviado:
+
+<table border="0">
+
+	<tbody>
+
+		{% for key,value in fields %}
+
+			<tr>
+				<th style="vertical-align: top; text-align: left; padding-right: 10px;">{{ key|upper }}</th>
+				<td style="text-align: left;">{{ value|raw|nl2br }}</td>
+			</tr>
+
+		{% endfor %}
+
+	</tbody>
+
+</table>
+
+{% endif %}
+
+
+Le saluda atentamente,
+
+El formulario de contacto
+
+
+==
+
+<p>Hola,</p>
+
+<p>esto es una notificación de un formulario de contacto..</p>
+
+{% if fields|length %}
+
+<br>
+
+<p>Sent form content:</p>
+
+<table border="0">
+
+	<tbody>
+
+		{% for key,value in fields %}
+
+			<tr>
+				<th style="vertical-align: top; text-align: left; padding-right: 10px;">{{ key|upper }}</th>
+				<td style="text-align: left;">{{ value|raw|nl2br }}</td>
+			</tr>
+
+		{% endfor %}
+
+	</tbody>
+
+</table>
+
+{% endif %}
+
+<br>
+
+<p>Le saluda atentamente,<br>
+
+El formulario de contacto</p>


### PR DESCRIPTION
For some reason, it seems to not be getting it automatically, but setting the template as janvince.smallcontactform::mail.autoreply_es will do.