### PR TITLE
Fix #133 : Set correct hostname for localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Implementation of Google reCaptcha antispam protection.
 
 First you have to create new API keys pair in reCaptcha admin panel.
 
-Hit **Get reCAPTCHA** button on [reCaptcha wellcome page](https://www.google.com/recaptcha). Set label and check reCAPTCHA v2 option and hit button Register. Note that you will have to add `localhost` to allowed domains list if you want the recaptcha validation to work locally.
+Hit **Get reCAPTCHA** button on [reCaptcha wellcome page](https://www.google.com/recaptcha). Set label and check reCAPTCHA v2 option and hit button Register. Note that you will have to add `localhost` to the allowed domains list if you want the recaptcha validation to work locally.
 
 Copy Site key and Secret key to Contact Form's settings fields.
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Implementation of Google reCaptcha antispam protection.
 
 First you have to create new API keys pair in reCaptcha admin panel.
 
-Hit **Get reCAPTCHA** button on [reCaptcha wellcome page](https://www.google.com/recaptcha). Set label and check reCAPTCHA v2 option and hit button Register.
+Hit **Get reCAPTCHA** button on [reCaptcha wellcome page](https://www.google.com/recaptcha). Set label and check reCAPTCHA v2 option and hit button Register. Note that you will have to add `localhost` to allowed domains list if you want the recaptcha validation to work locally.
 
 Copy Site key and Secret key to Contact Form's settings fields.
 

--- a/components/SmallContactForm.php
+++ b/components/SmallContactForm.php
@@ -23,6 +23,7 @@ class SmallContactForm extends ComponentBase
 
   private $validationRules;
   private $validationMessages;
+  private $validationReCaptchaServerName;
 
   private $postData = [];
   private $post;
@@ -282,6 +283,7 @@ class SmallContactForm extends ComponentBase
      * Validation
      */
     $this->setFieldsValidationRules();
+    $this->validationReCaptchaServerName = $_SERVER['SERVER_NAME'] == "127.0.0.1" ? "localhost" : $_SERVER['SERVER_NAME'];
     $errors = [];
 
     $this->post = Input::all();
@@ -357,7 +359,7 @@ class SmallContactForm extends ComponentBase
               $recaptcha = new ReCaptcha(Settings::get('google_recaptcha_secret_key'));
             }
 
-            $response = $recaptcha->setExpectedHostname($_SERVER['SERVER_NAME'])->verify(post('g-recaptcha-response'), $_SERVER['REMOTE_ADDR']);
+            $response = $recaptcha->setExpectedHostname($this->validationReCaptchaServerName)->verify(post('g-recaptcha-response'), $_SERVER['REMOTE_ADDR']);
         } 
         catch(\Exception $e) 
         {


### PR DESCRIPTION
Fixes #133 
ReCaptcha validation's `setExpectedHostname` should use `localhost` instead of `127.0.0.1`