### PR TITLE
Fix php 8.0 arg order error

### DIFF
--- a/models/Message.php
+++ b/models/Message.php
@@ -350,7 +350,7 @@ class Message extends Model
     /**
      * Build and send notification message
      */
-    public function sendNotificationEmail($postData, $componentProperties = [], $formAlias, $formDescription, $messageObject, $formNotes){
+    public function sendNotificationEmail($postData, $componentProperties, $formAlias, $formDescription, $messageObject, $formNotes){
 
         if(!Settings::getTranslated('allow_notifications')) {
             return;


### PR DESCRIPTION
Fixes #135 

If a parameter with a default value is followed by a required parameter, the default value has no effect. This is deprecated as of PHP 8.0.0 and can generally be resolved by dropping the default value.

Reference : https://www.php.net/manual/en/migration80.deprecated.php