### PR TITLE
[FIX] Weird translation bug on OC v3.x w/ RainLab.Translate v2

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -2,18 +2,11 @@
 
 namespace JanVince\SmallContactForm;
 
-use \Illuminate\Support\Facades\Event;
-use System\Classes\PluginBase;
-use System\Classes\PluginManager;
-use Config;
 use Backend;
 use Validator;
-use Log;
-
-
 use JanVince\SmallContactForm\Models\Settings;
 use JanVince\SmallContactForm\Rules\CustomNotRegexRule;
-use System;
+use System\Classes\PluginBase;
 
 class Plugin extends PluginBase {
 
@@ -36,14 +29,24 @@ class Plugin extends PluginBase {
         ];
     }
 
+    /**
+     * Register Plugin Hook
+     *
+     * @return void
+     */
     public function register() {
-        if (version_compare(System::VERSION, '3.0.0', '>=')) {
+        if (class_exists(\System::class) && version_compare(\System::VERSION, '3.0.0', '>=')) {
             $this->registerValidationRule('custom_not_regex', CustomNotRegexRule::class);
         }
     }
 
+    /**
+     * Boot Plugin Hook
+     *
+     * @return void
+     */
     public function boot() {
-        if (version_compare(System::VERSION, '3.0.0', '<')) {
+        if (!class_exists(\System::class) || (class_exists(\System::class) && version_compare(\System::VERSION, '3.0.0', '<'))) {
             Validator::extend('custom_not_regex', CustomNotRegexRule::class);
         }
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -12,7 +12,8 @@ use Log;
 
 
 use JanVince\SmallContactForm\Models\Settings;
-
+use JanVince\SmallContactForm\Rules\CustomNotRegexRule;
+use System;
 
 class Plugin extends PluginBase {
 
@@ -35,34 +36,16 @@ class Plugin extends PluginBase {
         ];
     }
 
+    public function register() {
+        if (version_compare(System::VERSION, '3.0.0', '>=')) {
+            $this->registerValidationRule('custom_not_regex', CustomNotRegexRule::class);
+        }
+    }
+
     public function boot() {
-
-        /**
-         * Custom Validator rules
-         */
-        Validator::extend('custom_not_regex', function ($attribute, $value, $parameters) {
-
-            if (is_array($parameters)) {
-                $param = $parameters[0];
-            } else {
-                $param = $parameters;
-            }
-
-            try {
-                $result = preg_match($param, $value);
-
-                if ($result === 1) {
-                    return false;
-                } else {
-                    return true;
-                }
-            } catch (\Exception $e) {
-                Log::error('Error in Small Contact Form custom_not_regex validation rule! ' . $e->getMessage());
-            }
-
-            return false;
-        });
-
+        if (version_compare(System::VERSION, '3.0.0', '<')) {
+            Validator::extend('custom_not_regex', CustomNotRegexRule::class);
+        }
     }
 
     public function registerSettings() {

--- a/rules/CustomNotRegexRule.php
+++ b/rules/CustomNotRegexRule.php
@@ -19,6 +19,18 @@ class CustomNotRegexRule
     {
         $param = is_array($params) ? $params[0] : $params;
 
+        // Fallback solution to add ':regex' replacer on OCv1 installations
+        if (!class_exists(\System::class)) {
+            /** @var \October\Rain\Validation\Validator */
+            $validator = func_get_arg(3);
+            if (!array_key_exists('custom_not_regex', $validator->replacers)) {
+                $self = $this;
+                $validator->addReplacer('custom_not_regex', function ($message, $attribute, $rule, $parameters) use ($self) {
+                    return $self->replace($message, $attribute, $rule, $parameters);
+                });
+            }
+        }
+
         try {
             $result = preg_match($param, $value);
 

--- a/rules/CustomNotRegexRule.php
+++ b/rules/CustomNotRegexRule.php
@@ -1,0 +1,61 @@
+<?php 
+
+namespace JanVince\SmallContactForm\Rules;
+
+use Log;
+
+class CustomNotRegexRule
+{
+
+    /**
+     * Validate Rule
+     * 
+     * @param string $attribute
+     * @param mixed $value
+     * @param array $params
+     * @return bool
+     */
+    public function validate($attribute, $value, $params): bool
+    {
+        $param = is_array($params) ? $params[0] : $params;
+
+        try {
+            $result = preg_match($param, $value);
+
+            if ($result === 1) {
+                return false;
+            } else {
+                return true;
+            }
+        } catch (\Exception $e) {
+            Log::error('Error in Small Contact Form custom_not_regex validation rule! ' . $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * Custom Validation Error Message
+     * 
+     * @return string
+     */
+    public function message(): string
+    {
+        return 'The :attribute must not match against ":regex".';
+    }
+
+    /**
+     * Replace Regex
+     *
+     * @param string $message
+     * @param string $attribute
+     * @param string $rule
+     * @param mixed $parameters
+     * @return string
+     */
+    public function replace($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':regex', $parameters[0], $message);
+    }
+
+}

--- a/rules/CustomNotRegexRule.php
+++ b/rules/CustomNotRegexRule.php
@@ -67,6 +67,10 @@ class CustomNotRegexRule
      */
     public function replace($message, $attribute, $rule, $parameters)
     {
+        // Laravel 5.5 Fallback solution for OCv1.0
+        if ($message === 'validation.custom_not_regex') {
+            $message = str_replace(':attribute', $attribute, $this->message());
+        }
         return str_replace(':regex', $parameters[0], $message);
     }
 

--- a/rules/CustomNotRegexRule.php
+++ b/rules/CustomNotRegexRule.php
@@ -8,7 +8,7 @@ class CustomNotRegexRule
 {
 
     /**
-     * Validate Rule
+     * Apply Validation Rule
      * 
      * @param string $attribute
      * @param mixed $value
@@ -25,8 +25,8 @@ class CustomNotRegexRule
             $validator = func_get_arg(3);
             if (!array_key_exists('custom_not_regex', $validator->replacers)) {
                 $self = $this;
-                $validator->addReplacer('custom_not_regex', function ($message, $attribute, $rule, $parameters) use ($self) {
-                    return $self->replace($message, $attribute, $rule, $parameters);
+                $validator->addReplacer('custom_not_regex', function () use ($self) {
+                    return call_user_func_array([$self, 'replace'], func_get_args());
                 });
             }
         }
@@ -47,7 +47,7 @@ class CustomNotRegexRule
     }
 
     /**
-     * Custom Validation Error Message
+     * Validation Error Message
      * 
      * @return string
      */
@@ -57,7 +57,7 @@ class CustomNotRegexRule
     }
 
     /**
-     * Replace Regex
+     * Replace Regex Placeholder
      *
      * @param string $message
      * @param string $attribute


### PR DESCRIPTION
Hello,

after going ~almost~ insane looking for the error, which prevents the localization system to correctly display the locale strings of my (and any) template (on the theme-config page), I figured out that the inclusion of the custom validation rule breaks something for some reason.

I have no idea why, but Laravel 9 or OctoberCMS v3.1 or RainLab.Translate v2 (whoever is to blame) loads the template locale `themes/[theme]/lang/[locale]/lang.php` files only, when the validation rule is added in the "new native" way (using a custom rule class + [`registerValidationRule()`](https://docs.octobercms.com/3.x/extend/services/validation.html#globally-registered-rules) instead of `Validator::extend`).

I've tested it with
- OctoberCMS v2 (based on Laravel 6 using RainLab.Translate v1)
- OctoberCMS v3 (based on Laravel 9 using RainLab.Translate v1)
- OctoberCMS v3 (based on Laravel 9 using RainLab.Translate v2)

and both works now: Your plugin (with your `custom_not_regex` rule, of course) and my NewsHub template localization (The error occurred at least on the last one, after installing your plugin and clearing the cache).

~ Sam.